### PR TITLE
Compulsory run passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## neptune-detectron2 0.2.0
+
+### Fixes
+- The NeptuneHook doesn't stop the run after training, just syncs. ([#7](https://github.com/neptune-ai/neptune-detectron2/pull/7))
+- Passing a run or handler object is now compulsory - the hook will not create one automatically. ([#7](https://github.com/neptune-ai/neptune-detectron2/pull/7))
+
+### Changes
+- Updated the integration for compatibility with `neptune-client` `1.0.0`. ([#6](https://github.com/neptune-ai/neptune-detectron2/pull/6))
+
 ## neptune_detectron2 0.1.0
 
 ### Fixes

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -9,7 +9,6 @@ from tests.utils import get_images
 def test_e2e(cfg, trainer):
 
     run = neptune.init_run()
-    run_id = run["sys/id"].fetch()
 
     get_images()
     os.makedirs(cfg.OUTPUT_DIR, exist_ok=True)
@@ -19,15 +18,14 @@ def test_e2e(cfg, trainer):
     trainer.register_hooks([hook])
     trainer.train()
 
-    npt_run = neptune.init_run(with_id=run_id)
+    assert run.exists("training/config")
 
-    assert npt_run.exists("training/config")
+    assert run.exists("model/checkpoints/checkpoint_iter_0")
 
-    assert npt_run.exists("model/checkpoints/checkpoint_iter_0")
+    assert run.exists("model/checkpoints/checkpoint_final")
 
-    assert npt_run.exists("model/checkpoints/checkpoint_final")
+    assert isinstance(run["training/model/summary"].fetch(), str)
 
-    assert isinstance(npt_run["training/model/summary"].fetch(), str)
-
-    cls_accuracy_vals = npt_run["training/metrics/fast_rcnn/cls_accuracy"].fetch_values()
+    cls_accuracy_vals = run["training/metrics/fast_rcnn/cls_accuracy"].fetch_values()
     assert 0 < cls_accuracy_vals.iloc[-1]["value"] <= 1
+    run.stop()


### PR DESCRIPTION
Applying @kshitij12345 suggestions that the run object should be created outside of the hook and stopping it afterwards is not the hook's responsibility either.

Also adding the changelog entries that I forgot to append last time (after-deprecation integration update). Will create a release upon  successful merge of this PR.