### PR TITLE
update integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ python = "^3.7"
 # Python lack of functionalities from future versions
 importlib-metadata = { version = "*", python = "<3.8" }
 
-neptune = ">=1.0.0"
 numpy = "<1.24.0"
 fvcore = "<0.1.5.post20221220"
 
@@ -22,14 +21,18 @@ fvcore = "<0.1.5.post20221220"
 pre-commit = { version = "*", optional = true }
 pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
-torch = "^1.13.0"
-torchvision = "^0.14.0"
+torch = { version = "^1.13.0", optional = true }
+torchvision = { version = "^0.14.0", optional = true }
+neptune = { version = ">=1.0.0", optional = true }
 
 [tool.poetry.extras]
 dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "torch",
+    "torchvision",
+    "neptune",
 ]
 
 [tool.poetry]

--- a/src/neptune_detectron2/impl/__init__.py
+++ b/src/neptune_detectron2/impl/__init__.py
@@ -74,7 +74,7 @@ class NeptuneHook(hooks.HookBase):
         neptune_hook = NeptuneHook(
             run=neptune_run,
             log_checkpoints=True,  # Log model checkpoints
-            smoothing_window_size=10,  # Upload metrics and checkpoints every 10th epoch
+            metrics_update_freq=10,  # Upload metrics and checkpoints every 10th epoch
         )
 
     For more, see the docs:

--- a/src/neptune_detectron2/impl/__init__.py
+++ b/src/neptune_detectron2/impl/__init__.py
@@ -62,7 +62,7 @@ class NeptuneHook(hooks.HookBase):
         base_namespace: Root namespace where all metadata logged by the hook is stored.
         metrics_update_freq: How often NeptuneHook should log metrics (and checkpoints, if
             log_checkpoints is set to True). The value must be greater than zero.
-            Example: Setting smoothing_window_size=10 will log metrics on every 10th epoch.
+            Example: Setting metrics_update_freq=10 will log metrics on every 10th epoch.
         log_model: Whether to upload the final model checkpoint, whenever it is saved by the Trainer.
             Expects CheckpointHook to be present.
         log_checkpoints: Whether to upload checkpoints whenever they are saved by the Trainer.
@@ -99,7 +99,7 @@ class NeptuneHook(hooks.HookBase):
         self.log_model = log_model
         self.log_checkpoints = log_checkpoints
 
-        self._verify_window_size()
+        self._verify_metrics_update_freq()
 
         if base_namespace.endswith("/"):
             base_namespace = base_namespace[:-1]
@@ -108,13 +108,13 @@ class NeptuneHook(hooks.HookBase):
 
         self._root_object = self._run.get_root_object() if isinstance(self._run, Handler) else self._run
 
-    def _verify_window_size(self) -> None:
-        if self._metrics_update_freq <= 0:
-            raise ValueError(f"Update freq should be greater than 0. Got {self._metrics_update_freq}.")
+    def _verify_metrics_update_freq(self) -> None:
         if not isinstance(self._metrics_update_freq, int):
             raise TypeError(
-                f"Smoothing window size should be of type int. Got {type(self._metrics_update_freq)} instead."
+                f"metrics_update_freq should be of type int. Got {type(self._metrics_update_freq)} instead."
             )
+        if self._metrics_update_freq <= 0:
+            raise ValueError(f"metrics_update_freq should be greater than 0. Got {self._metrics_update_freq}.")
 
     def _log_integration_version(self) -> None:
         self._root_object[INTEGRATION_VERSION_KEY] = detectron2.__version__

--- a/src/neptune_detectron2/impl/__init__.py
+++ b/src/neptune_detectron2/impl/__init__.py
@@ -31,14 +31,23 @@ import warnings
 import detectron2
 from detectron2.checkpoint import Checkpointer
 from detectron2.engine import hooks
-from neptune import Run
-from neptune.handler import Handler
-from neptune.internal.utils import verify_type
-from neptune.types import File
-from neptune.utils import stringify_unsupported
-from torch.nn import Module
 
 from neptune_detectron2.impl.version import __version__
+
+try:
+    from neptune import Run
+    from neptune.handler import Handler
+    from neptune.internal.utils import verify_type
+    from neptune.types import File
+    from neptune.utils import stringify_unsupported
+except ImportError:
+    from neptune.new.metadata_containers import Run
+    from neptune.new.handler import Handler
+    from neptune.new.internal.utils import verify_type
+    from neptune.new.types import File
+    from neptune.new.utils import stringify_unsupported
+
+from torch.nn import Module
 
 INTEGRATION_VERSION_KEY = "source_code/integrations/detectron2"
 
@@ -67,7 +76,7 @@ class NeptuneHook(hooks.HookBase):
             log_checkpoints=True,  # Log model checkpoints
             smoothing_window_size=10,  # Upload metrics and checkpoints every 10th epoch
         )
-    
+
     For more, see the docs:
         Tutorial: https://docs.neptune.ai/integrations/detectron2/
         API reference: https://docs.neptune.ai/api/integrations/detectron2/

--- a/src/neptune_detectron2/impl/version.py
+++ b/src/neptune_detectron2/impl/version.py
@@ -1,6 +1,7 @@
 __all__ = ["__version__"]
 
 import sys
+from importlib.util import find_spec
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import (
@@ -12,6 +13,14 @@ else:
         PackageNotFoundError,
         version,
     )
+
+if not (find_spec("neptune") or find_spec("neptune-client")):
+    msg = """
+            The Neptune client library was not found.
+            Install the neptune package with
+                `pip install neptune`
+            Need help? -> https://docs.neptune.ai/setup/installation/"""
+    raise PackageNotFoundError(msg)
 
 try:
     __version__ = version("neptune-detectron2")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,6 +1,9 @@
 import os
 
-from neptune import init_run
+try:
+    from neptune import init_run
+except ImportError:
+    from neptune.new import init_run
 
 from src.neptune_detectron2 import NeptuneHook
 from tests.utils import get_images


### PR DESCRIPTION
## What's changing:
- neither `neptune` nor `neptune-client` is part of the requirements
- integration stays compatible with both major versions of the client
- in case neither `neptune` nor `neptune-client` is installed, an appropriate exception is raised with instructions for installation
- refactored parameter name: `smoothing_window_size` -> `metrics_update_freq`